### PR TITLE
feat: add skip tls for cert-manager

### DIFF
--- a/charts/qovery/charts/cert-manager-configs/templates/clusterissuer.yaml
+++ b/charts/qovery/charts/cert-manager-configs/templates/clusterissuer.yaml
@@ -7,6 +7,7 @@ spec:
   acme:
     server: {{ .Values.acme.letsEncrypt.acmeUrl }}
     email: {{ .Values.acme.letsEncrypt.emailReport }}
+    skipTLSVerify: {{ .Values.acme.letsEncrypt.skipTLSVerify }}
 
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:

--- a/charts/qovery/charts/cert-manager-configs/values.yaml
+++ b/charts/qovery/charts/cert-manager-configs/values.yaml
@@ -22,3 +22,4 @@ acme:
   letsEncrypt:
     emailReport: ""
     acmeUrl: ""
+    skipTLSVerify: false


### PR DESCRIPTION
Add an option to skip tls verify on acme provider to be able to retrieve certs in testing environement with https://github.com/letsencrypt/pebble